### PR TITLE
Don't abort batches on error

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,10 +66,7 @@ func main() {
 	}()
 
 	for {
-		curTime, err = pollr.PollLogsSendEvents(curTime)
-		if err != nil {
-			log.Errorf("Could not poll/convert/send events: %v", err)
-		}
+		curTime = pollr.PollLogsSendEvents(curTime)
 		go func() {
 			time.Sleep(cfg.PollInterval)
 			loopChan <- "timeout"


### PR DESCRIPTION
When reading a batch of audit events, if any event has an error with
conversion, parsing, etc. PollLogsSendEvents returns immediately with an
error and gives up on the rest of the batch.

Change this to logging an error + continue instead, so every event in
the batch gets a chance to be converted.