### PR TITLE
Lag behind realtime by (cfgable) interval

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,16 +21,12 @@ func main() {
 
 	cfg := model.NewConfig()
 
-	dur, err := time.ParseDuration("5s")
-	if err != nil {
-		log.Fatalf("Could not parse duration '5s': %v", err)
-	}
-
 	flag.StringVar(&cfg.Url, "url", "http://sysdig-agent.sysdig-agent.svc.cluster.local:7765/k8s_audit", "send generated events to this url")
 	flag.StringVar(&cfg.ProjectArg, "project", "", "read logs from provided project. If blank, use metadata service to find project id")
 	flag.StringVar(&cfg.LogfileName, "logfile", "", "if set, write all log entries to provided file")
 	flag.StringVar(&cfg.OutfileName, "outfile", "", "if set, also append converted audit logs to provided file")
-	flag.DurationVar(&cfg.PollInterval, "poll_interval", dur, "poll interval for log messages")
+	flag.DurationVar(&cfg.PollInterval, "poll_interval", 5 * time.Second, "poll interval for log messages")
+	flag.DurationVar(&cfg.LagInterval, "lag_interval", 30 * time.Second, "lag behind current time when reading log entries")
 	flag.StringVar(&cfg.LogLevel, "log_level", "info", "log level")
 
 	log.SetLevel(log.InfoLevel)
@@ -55,7 +51,7 @@ func main() {
 
 	defer pollr.Close()
 
-	curTime := time.Now().UTC().Add(-1 * cfg.PollInterval)
+	curTime := time.Now().UTC().Add(-2 * cfg.LagInterval)
 
 	loopChan := make(chan string)
 	signalChan := make(chan os.Signal, 2)

--- a/model/model.go
+++ b/model/model.go
@@ -27,6 +27,7 @@ type Config struct {
 	OutfileName         string
 	LogfileName         string
 	PollInterval        time.Duration
+	LagInterval         time.Duration
 	MaxAuditEventsBatch int
 	LogLevel            string
 }
@@ -37,7 +38,8 @@ func NewConfig() *Config {
 		ProjectArg:          "",
 		OutfileName:         "",
 		LogfileName:         "",
-		PollInterval:        5,
+		PollInterval:        5 * time.Second,
+		LagInterval:         30 * time.Second,
 		MaxAuditEventsBatch: 100,
 	}
 }


### PR DESCRIPTION
We noticed that in some cases there would be gaps in the log entries
read by the reader. You can observe this same behavior by using the web
based stackdriver UI and repeatedly refreshing for new logs.

To address this, add a configurable lag interval. When reading log
entries, only read up to now-the lag interval. The default is 30
seconds, meaning that the bridge will always read entries up to 30
seconds ago.